### PR TITLE
change to include 'include' directory into 'include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
+  include
   ${catkin_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
This will fix
```
Errors     << 3D_object_detection:make /tmp/hoge/logs/3D_object_detection/build.make.005.log
/tmp/hoge/src/3D_object_detection/src/3D_object_detection.cpp:20:42: fatal error: 3D_object_detection/hough_3d.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/3D_object_detection.dir/src/3D_object_detection.cpp.o] Error 1
make[1]: *** [CMakeFiles/3D_object_detection.dir/all] Error 2
make: *** [all] Error 2
```

to debug this kind of problem, first run with `catkin b -vi --make-args VERBOSE=1`.

This will outputs something like
```
[3D_object_detection:make] /usr/bin/c++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"3D_object_detection\" -I/opt/ros/kinetic/include -I/opt/ros/kinetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -I/usr/include/eigen3 -I/usr/include/pcl-1.7 -I/usr/include/ni -I/usr/include/vtk-6.2 -I/usr/include/x86_64-linux-gnu -I/usr/include/freetype2 -I/usr/lib/openmpi/include/openmpi/opal/mca/event/libevent2021/libevent -I/usr/lib/openmpi/include/openmpi/opal/mca/event/libevent2021/libevent/include -I/usr/lib/openmpi/include -I/usr/lib/openmpi/include/openmpi -I/usr/include/jsoncpp -I/usr/include/python2.7 -I/usr/include/libxml2 -I/usr/include/tcl   -o CMakeFiles/3D_object_detection.dir/src/3D_object_detection.cpp.o -c /tmp/hoge/src/3D_object_detection/src/3D_object_detection.cpp
```

and carefully check all -I options